### PR TITLE
ci: Add GitHub action to run tests and golangci-lint

### DIFF
--- a/.github/on_pull_request.yaml
+++ b/.github/on_pull_request.yaml
@@ -1,0 +1,36 @@
+name: On creation or updates to a pull request
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: './go.mod'
+      - name: Install dependencies
+        run: go get ./...
+      - name: Build
+        run: go build -v ./...
+      - name: Test
+        run: go test -v ./...
+
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: './go.mod'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.63.4


### PR DESCRIPTION
Adds an action to run on any PR changes. The action runs `golangci-lint` and `go test`. There are no tests currently but when some are added they will be automatically run.